### PR TITLE
Dynamically load lines feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The following settings are available:
 | `progressChar` | string | `'█'` | Character to use for progress bar. |
 | `cursor` | string | `'▋'` | Character to use for cursor. |
 | `noInit` | boolean | `false` | Don't initialise the animation on load. This means you can call `Termynal.init()` yourself whenever and however you want.
+| `lineData` | Object[] | `null` | [Dynamically load](#dynamically-loading-lines) lines at instantiation.
 
 ## Prompts and animations
 
@@ -137,4 +138,21 @@ You can also change the cursor style and animation in [`termynal.css`](termynal.
     -webkit-animation: blink 1s infinite;
             animation: blink 1s infinite;
 }
+```
+
+### Dynamically loading lines
+
+Lines can be dynamically loaded by passing an array of line data objects, using the [attribute suffixes](#data-ty-prompt-prompt-style), as a property of the [settings](#customising-termynal) object.
+
+```javascript
+var termynal = new Termynal('#termynal',
+    {
+        lineData: [
+            { type: 'input', value: 'pip install spacy' },
+            { value: 'Are you sure you want to install \'spaCy\'?' },
+            { type: 'input',  typeDelay: 1000, prompt: '(y/n)', value: 'y' },
+            { delay: 1000, value: 'Installing spaCy...' }
+        ]
+    }
+)
 ```

--- a/example3.html
+++ b/example3.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <title>termynal.js example</title>
+        <meta charset="utf-8">
+        <!-- include the termynal stylesheet -->
+        <link rel="stylesheet" href="termynal.css">
+        <!-- some custom styles for the page -->
+        <link href="https://fonts.googleapis.com/css?family=Fira+Mono">
+        <style>
+            body {
+                --color-bg: #ddd;
+                --color-text: #1a1e24;
+                --color-text-subtle: #D76D77;
+
+                padding: 0; margin: 0;
+                background: -webkit-linear-gradient(to right, #3a1c71, #d76d77, #ffaf7b);
+  background: linear-gradient(to right, #3a1c71, #d76d77, #ffaf7b);
+                width: 100%;
+                min-height: 100vh;
+                display: -webkit-box; display: -ms-flexbox; display: flex;
+                -webkit-box-align: center; -ms-flex-align: center; align-items: center;
+                -webkit-box-pack: center; -ms-flex-pack: center; justify-content: center;
+                -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale;
+            }
+        </style>
+    </head>
+    <body>
+        <!-- the termynal container -->
+        <div id="termynal"></div>
+
+        <!-- include and initialise termynal.js -->
+        <script src="termynal.js"></script>
+        <script>
+          var termynal = new Termynal('#termynal', {
+            typeDelay: 40,
+            lineDelay: 700,
+            lineData: [
+              { type: 'input', prompt: '▲', value: 'npm uninstall react' },
+              { value: 'Are you sure you want to uninstall \'react\'?' },
+              { type: 'input',  typeDelay: 1000, prompt: '(y/n)', value: 'y' },
+              { type: 'progress', progressChar: '·' },
+              { value: 'Uninstalled \'react\'' },
+              { type: 'input', prompt:'▲', value: 'node' },
+              { type: 'input', prompt: '>', value: `Array(5).fill('🦄 ')` },
+              { value: `['🦄', '🦄', '🦄', '🦄', '🦄']` },
+              { type: 'input', prompt: '▲', value: 'cd ~/repos' },
+              { type: 'input', prompt: '▲ ~/repos', value: ' git checkout branch master' },
+              { type: 'input', prompt: '▲ ~/repos (master)', value: 'git commit -m \'Fix things\'' },
+            ]
+          });
+        </script>
+    </body>
+</html>

--- a/termynal.js
+++ b/termynal.js
@@ -146,33 +146,36 @@ class Termynal {
      * 
      * @param {Object[]} lineData - Dynamically loaded lines.
      * @param {Object} line - Line data object.
-     * @param {string} line.value - Text content to use in the line element.
-     * @param {string} line.type - Display and animation style.
-     * @param {string} line.prompt - Prefix for a line element.
-     * @param {number} line.typeDelay - Delay between each typed character, in ms.
-     * @param {number} line.delay - Delay before next line, in ms.
-     * @param {number} line.progressLength - Number of characters displayed as progress bar.
-     * @param {string} line.progressChar - Character to use for progress bar, defaults to █.
-     * @param {string} line.cursor - Character to use for cursor, defaults to ▋.
      * @returns {Element[]} - Array of line elements.
      */
     lineDataToElements(lineData) {
         return lineData.map(line => {
             let div = document.createElement('div');
-            div.innerHTML = `
-                <span
-                    ${this.pfx}="${line.type || ''}"
-                    ${line.prompt ? `${this.pfx}-prompt="${line.prompt}"` : ''}
-                    ${line.typeDelay ? `${this.pfx}-typeDelay="${line.typeDelay}"` : ''}
-                    ${line.delay ? `${this.pfx}-delay="${line.delay}"` : ''}
-                    ${line.progressLength ? `${this.pfx}-progressLength="${line.progressLength}"` : ''}
-                    ${line.progressChar ? `${this.pfx}-progressChar="${line.progressChar}"` : ''}
-                    ${line.cursor ? `${this.pfx}-cursor="${line.cursor}"` : ''}
-                >${line.value || ''}</span>
-            `;
-          
+            div.innerHTML = `<span ${this._attributes(line)}>${line.value || ''}</span>`;
+
             return div.firstElementChild;
         });
+    }
+
+    /**
+     * Helper function for generating attributes string.
+     * 
+     * @param {Object} line - Line data object.
+     * @returns {string} - String of attributes.
+     */
+    _attributes(line) {
+        let attrs = '';
+        for (let prop in line) {
+            attrs += this.pfx;
+
+            if (prop === 'type') {
+                attrs += `="${line[prop]}" `
+            } else if (prop !== 'value') {
+                attrs += `-${prop}="${line[prop]}" `
+            }
+        }
+
+        return attrs;
     }
 }
 


### PR DESCRIPTION
Added the ability to dynamically load line elements (fixes #4) by passing an array of objects into the `lineData` property of the `options` object into the constructor of `Termynal` class.

I've tried to maintain as much consistency with the existing codebase as possible, including an example and updated README. One step that would still need to be completed is updating the minification of `termynal.min.js`; unsure of what tool is being used for minification, I wanted to leave that up to the creator/maintainer to keep it consistent.

Also, adding a `package.json` and pushing this to `npm` would be super. I'm a huge fan of this project and it'd be great to make it more accessible to developers.