### PR TITLE
Allow passing a class to dynamically generated lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ You can also change the cursor style and animation in [`termynal.css`](termynal.
 
 ### Dynamically loading lines
 
-Lines can be dynamically loaded by passing an array of line data objects, using the [attribute suffixes](#data-ty-prompt-prompt-style), as a property of the [settings](#customising-termynal) object.
+Lines can be dynamically loaded by passing an array of line data objects, using the [attribute suffixes](#data-ty-prompt-prompt-style), as a property of the [settings](#customising-termynal) object. You can also pass a `class` attribute to customize the styles in the generated `<span>`s.
 
 ```javascript
 var termynal = new Termynal('#termynal',
@@ -158,6 +158,7 @@ var termynal = new Termynal('#termynal',
             { type: 'input', value: 'pip install spacy' },
             { value: 'Are you sure you want to install \'spaCy\'?' },
             { type: 'input',  typeDelay: 1000, prompt: '(y/n)', value: 'y' },
+            { value: 'this will take a moment', class: 'comment' },
             { delay: 1000, value: 'Installing spaCy...' }
         ]
     }

--- a/termynal.js
+++ b/termynal.js
@@ -174,6 +174,10 @@ class Termynal {
     _attributes(line) {
         let attrs = '';
         for (let prop in line) {
+            if (prop === 'class') {
+                attrs += ` class=${line[prop]} `
+                continue
+            }
             attrs += this.pfx;
 
             if (prop === 'type') {


### PR DESCRIPTION
This allows setting a custom `class` in the generated `<span>`s when loading data dynamically.

---

@justindujardin showed termynal to me and I'm loving it! I just added it to Typer for the docs. :tada: 

I'm using a version with this patch, to generate termynals on the fly from Markdown fenced code. That way it still shows as Markdown "code" in GitHub, but it looks great on the docs' website.