### PR TITLE
support for html tags for coloring inside of the data-ty=input + example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Each `<span>` within the container represents a line of code. You can customise 
 | `input` | Simple prompt with user input and cursor | `<span data-ty="input">pip install spacy</span>` |
 | `progress` | Animated progress bar | `<span data-ty="progress"></span>` |
 
+Both `data-ty` and `data-ty="input"` support html tags inside the text. This is useful for highlighting parts of the text with specific colors or styles. See the [simple example](example.html) for an example.
+
 ### `data-ty-prompt`: prompt style
 
 The prompt style specifies the characters that are displayed before each line, for example, to indicate command line inputs or interpreters (like `>>>` for Python). By default, Termynal displays a `$` before each user input line.

--- a/example.html
+++ b/example.html
@@ -22,17 +22,17 @@
     </head>
     <body>
         <!-- the termynal container -->
-        <div id="termynal" data-termynal>
-            <span data-ty="input">pip install spacy</span>
+        <div id="termynal">
+            <span data-ty="input">pip install <i style="color: red">spacy</i></span>
             <span data-ty="progress"></span>
-            <span data-ty>Successfully installed spacy</span>
+            <span data-ty>Successfully installed <i style="color: red">spacy</i></span>
             <span data-ty></span>
-            <span data-ty="input">python -m spacy download en</span>
+            <span data-ty="input">python -m <i style="color: red">spacy</i> download en</span>
             <span data-ty="progress"></span>
             <span data-ty>Installed model 'en'</span>
             <span data-ty></span>
             <span data-ty="input">python</span>
-            <span data-ty="input" data-ty-prompt=">>>">import spacy</span>
+            <span data-ty="input" data-ty-prompt=">>>">import <i style="color: red">spacy</i></span>
             <span data-ty="input" data-ty-prompt=">>>">nlp = spacy.load('en')</span>
             <span data-ty="input" data-ty-prompt=">>>">doc = nlp(u'Hello world')</span>
             <span data-ty="input" data-ty-prompt=">>>">print([(w.text, w.pos_) for w in doc])</span>


### PR DESCRIPTION
I need to add coloring to specific things inside of the both data-ty and data-ty="input" but it didn't work for input. I've added the code to support this and updated the example.

<img width="818" alt="Screenshot 2025-03-01 at 7 52 04 AM" src="https://github.com/user-attachments/assets/db885779-c580-494d-9209-edb912c8d8e8" />
